### PR TITLE
ci: use homelab runner set

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,26 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh pr list:*)",
+      "Bash(npm install:*)",
+      "Bash(npm run typecheck:*)",
+      "Bash(npm run lint)",
+      "Bash(git fetch:*)",
+      "Bash(git merge:*)",
+      "Bash(gh run list:*)",
+      "Bash(gh run view:*)",
+      "Bash(gh run watch:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(gh workflow run:*)",
+      "Bash(gh workflow:*)",
+      "Bash(npm run lint:*)",
+      "Bash(cat:*)",
+      "mcp__github__get_pull_request",
+      "mcp__github__get_pull_request_status",
+      "mcp__github__merge_pull_request",
+      "Bash(git checkout:*)",
+      "Bash(git pull:*)"
+    ]
+  }
+}

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - discord-plays-pokemon-runner-set

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   dagger-ci:
-    runs-on: ubuntu-latest
+    runs-on: [discord-plays-pokemon-runner-set]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -18,11 +18,49 @@ jobs:
           node-version: "lts/*"
           cache: "npm"
 
+      - name: Extract kubectl version
+        id: kubectl-version
+        run: |
+          KUBECTL_VERSION=v1.34.1
+          echo "version=$KUBECTL_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Cache kubectl
+        uses: actions/cache@v4
+        id: kubectl-cache
+        with:
+          path: ~/.local/bin/kubectl
+          key: kubectl-${{ steps.kubectl-version.outputs.version }}-linux-amd64
+
+      - name: Install kubectl
+        if: steps.kubectl-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/.local/bin
+          curl -LO "https://dl.k8s.io/release/${{ steps.kubectl-version.outputs.version }}/bin/linux/amd64/kubectl"
+          chmod +x kubectl
+          mv kubectl ~/.local/bin/
+
+      - name: Add kubectl to PATH
+        run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Extract Dagger version
+        id: dagger-version
+        run: |
+          # Get the Dagger version from the running dagger-dagger-helm-engine pod
+          DAGGER_IMAGE=$(kubectl get pod --selector=name=dagger-dagger-helm-engine --namespace=dagger -o jsonpath='{.items[0].spec.containers[0].image}')
+          # Extract version from image tag (e.g., "registry.dagger.io/engine:v0.18.12" -> "0.18.12")
+          DAGGER_VERSION="${DAGGER_IMAGE##*:v}"
+          echo "Detected Dagger version: $DAGGER_VERSION"
+          echo "version=$DAGGER_VERSION" >> "$GITHUB_OUTPUT"
+
       - name: Install Dagger CLI
         run: |
-          curl -L https://dl.dagger.io/dagger/install.sh | sh
-          sudo mv bin/dagger /usr/local/bin
-          dagger version
+          curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ steps.dagger-version.outputs.version }} BIN_DIR=$HOME/.local/bin sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Get Dagger Engine Pod Name
+        run: |
+          DAGGER_ENGINE_POD_NAME="$(kubectl get pod --selector=name=dagger-dagger-helm-engine --namespace=dagger --output=jsonpath='{.items[0].metadata.name}')"
+          echo "DAGGER_ENGINE_POD_NAME=$DAGGER_ENGINE_POD_NAME" >> "$GITHUB_ENV"
 
       - name: Install dependencies
         run: npm ci
@@ -33,6 +71,7 @@ jobs:
           GHCR_USERNAME: ${{ github.actor }}
           GHCR_PASSWORD: ${{ github.token }}
           DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+          _EXPERIMENTAL_DAGGER_RUNNER_HOST: kube-pod://${{ env.DAGGER_ENGINE_POD_NAME }}?namespace=dagger
         run: |
           dagger call ci \
             --source=. \
@@ -46,6 +85,7 @@ jobs:
         if: github.event_name == 'pull_request' || github.ref != 'refs/heads/main'
         env:
           DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+          _EXPERIMENTAL_DAGGER_RUNNER_HOST: kube-pod://${{ env.DAGGER_ENGINE_POD_NAME }}?namespace=dagger
         run: |
           dagger call ci \
             --source=. \

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   dependabot:
-    runs-on: ubuntu-latest
+    runs-on: [discord-plays-pokemon-runner-set]
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: Dependabot metadata


### PR DESCRIPTION
## Summary
- Switch from ubuntu-latest to discord-plays-pokemon-runner-set
- Add kubectl-based Dagger engine discovery
- Use external Dagger engine via _EXPERIMENTAL_DAGGER_RUNNER_HOST
- Add actionlint.yaml for runner validation

## Test plan
- [ ] Verify CI runs successfully on the homelab runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)