### PR TITLE
fix(ci): get bun.lock from workspace root in Docker build

### DIFF
--- a/.dagger/src/docker.ts
+++ b/.dagger/src/docker.ts
@@ -45,7 +45,7 @@ export async function buildDockerImage(
       "540",
     ])
     .withFile("package.json", backendDir.file("package.json"))
-    .withFile("bun.lock", backendDir.file("bun.lock"))
+    .withFile("bun.lock", workspaceSource.file("bun.lock"))
     .withDirectory("packages/backend", backendDir)
     .withDirectory("packages/frontend", frontendDist)
     .withFile("run.sh", workspaceSource.file("misc/run.sh"))


### PR DESCRIPTION
## Summary
- Fix CI failure where Docker build was looking for `bun.lock` in `packages/backend/` but it only exists at the workspace root
- The error was: `failed to get content hash: /workspace/packages/backend/bun.lock: file does not exist`

## Test plan
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)