### PR TITLE
fix(ci): clear base image entrypoint before running exec commands

### DIFF
--- a/.dagger/src/docker.ts
+++ b/.dagger/src/docker.ts
@@ -22,6 +22,7 @@ export async function buildDockerImage(
   return dag
     .container()
     .from("ghcr.io/selkies-project/nvidia-egl-desktop:24.04-20241222100454")
+    .withoutEntrypoint()
     .withEnvVariable("DEBIAN_FRONTEND", "noninteractive")
     .withUser("root")
     .withExec(["apt", "update"])


### PR DESCRIPTION
## Summary
- Fix Docker image build failure caused by the base image's supervisord ENTRYPOINT intercepting withExec commands
- Added `.withoutEntrypoint()` after `.from()` to ensure apt, curl, and other commands run correctly
- Error was: `Error: positional arguments are not supported: ['apt', 'update']` with hint `For help, use /usr/bin/supervisord -h`

## Context
This is a follow-up fix to #194 which fixed the bun.lock file path issue. After that fix, the Docker image build started but failed because the base image's entrypoint was interfering with build commands.

## Test plan
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)