### PR TITLE
fix(ci): use native Dagger methods for container publish

### DIFF
--- a/.dagger/src/docker.ts
+++ b/.dagger/src/docker.ts
@@ -1,5 +1,4 @@
 import { Directory, Container, Secret, dag } from "@dagger.io/dagger";
-import { publishToGhcrMultiple } from "@shepherdjerred/dagger-utils";
 import { getBackendWithDeps } from "./backend";
 import { getFrontendBuild } from "./frontend";
 
@@ -86,13 +85,17 @@ export async function publishDockerImage(
     throw new Error("GHCR credentials are required for publishing");
   }
 
-  return publishToGhcrMultiple({
-    container: image,
-    imageRefs: [
-      `ghcr.io/shepherdjerred/discord-plays-pokemon:${version}`,
-      `ghcr.io/shepherdjerred/discord-plays-pokemon:latest`,
-    ],
-    username: registryUsername,
-    password: registryPassword,
-  });
+  // Apply registry auth to the container
+  const authenticatedImage = image.withRegistryAuth("ghcr.io", registryUsername, registryPassword);
+
+  // Publish to both version and latest tags
+  const versionRef = `ghcr.io/shepherdjerred/discord-plays-pokemon:${version}`;
+  const latestRef = `ghcr.io/shepherdjerred/discord-plays-pokemon:latest`;
+
+  const [versionResult, latestResult] = await Promise.all([
+    authenticatedImage.publish(versionRef),
+    authenticatedImage.publish(latestRef),
+  ]);
+
+  return [versionResult, latestResult];
 }


### PR DESCRIPTION
## Summary
- Replace `publishToGhcrMultiple` utility with native Dagger `withRegistryAuth` and `publish` methods
- The utility function appeared to have issues with properly applying registry authentication to all publish operations, resulting in `exit code: 1` errors during publish

## Context
This is a follow-up to #195. After fixing the entrypoint issue, the Docker image builds successfully but publishing to GHCR fails with `exit code: 1`. Analysis of the logs showed that one of the publish calls was not having registry auth applied.

## Changes
- Removed dependency on `publishToGhcrMultiple` from `@shepherdjerred/dagger-utils`
- Directly use `container.withRegistryAuth()` and `container.publish()` for both image tags
- Both version-tagged and `latest` images now share the same authenticated container

## Test plan
- [ ] CI passes on this PR
- [ ] Main branch CI passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)