### PR TITLE
fix(ci): set explicit PATH instead of relying on $PATH expansion

### DIFF
--- a/.dagger/src/docker.ts
+++ b/.dagger/src/docker.ts
@@ -27,7 +27,7 @@ export async function buildDockerImage(
     .withExec(["apt", "update"])
     .withExec(["apt", "install", "-y", "curl", "kde-config-screenlocker", "unzip"])
     .withExec(["sh", "-c", "curl -fsSL https://bun.sh/install | bash"])
-    .withEnvVariable("PATH", "/root/.bun/bin:/home/ubuntu/.bun/bin:$PATH")
+    .withEnvVariable("PATH", "/root/.bun/bin:/home/ubuntu/.bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
     .withWorkdir("/home/ubuntu")
     .withExec(["mkdir", "-p", "data"])
     .withUser("ubuntu")


### PR DESCRIPTION
## Summary
- Fixed PATH environment variable in Docker build that was causing `mkdir: executable file not found in $PATH` errors
- The base image entrypoint sets up PATH, but since we clear it with `withoutEntrypoint()`, `$PATH` doesn't expand
- Now using explicit PATH with standard Unix directories

## Test plan
- [ ] CI passes and Docker image publishes successfully
- [ ] dpp-docs pod starts without ImagePullBackOff

🤖 Generated with [Claude Code](https://claude.com/claude-code)