### PR TITLE
revert: use dagger-utils for container publish

### DIFF
--- a/.dagger/src/docker.ts
+++ b/.dagger/src/docker.ts
@@ -1,4 +1,5 @@
 import { Directory, Container, Secret, dag } from "@dagger.io/dagger";
+import { publishToGhcrMultiple } from "@shepherdjerred/dagger-utils";
 import { getBackendWithDeps } from "./backend";
 import { getFrontendBuild } from "./frontend";
 
@@ -85,17 +86,13 @@ export async function publishDockerImage(
     throw new Error("GHCR credentials are required for publishing");
   }
 
-  // Apply registry auth to the container
-  const authenticatedImage = image.withRegistryAuth("ghcr.io", registryUsername, registryPassword);
-
-  // Publish to both version and latest tags
-  const versionRef = `ghcr.io/shepherdjerred/discord-plays-pokemon:${version}`;
-  const latestRef = `ghcr.io/shepherdjerred/discord-plays-pokemon:latest`;
-
-  const [versionResult, latestResult] = await Promise.all([
-    authenticatedImage.publish(versionRef),
-    authenticatedImage.publish(latestRef),
-  ]);
-
-  return [versionResult, latestResult];
+  return publishToGhcrMultiple({
+    container: image,
+    imageRefs: [
+      `ghcr.io/shepherdjerred/discord-plays-pokemon:${version}`,
+      `ghcr.io/shepherdjerred/discord-plays-pokemon:latest`,
+    ],
+    username: registryUsername,
+    password: registryPassword,
+  });
 }


### PR DESCRIPTION
## Summary
- Reverts #196 back to using `publishToGhcrMultiple` from `@shepherdjerred/dagger-utils`
- Prefer using the shared library over inlining native Dagger methods

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)