### PR TITLE
Migrate docs from container deployment to S3 deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
           export-env: true
         env:
           DAGGER_CLOUD_TOKEN: op://bic45kuflnwsnxnd67dzcnxjze/5p65mbzr237yyzt2sfnfao3a5a/DAGGER_CLOUD_TOKEN
+          S3_ACCESS_KEY_ID: op://bic45kuflnwsnxnd67dzcnxjze/5p65mbzr237yyzt2sfnfao3a5a/S3_ACCESS_KEY_ID
+          S3_SECRET_ACCESS_KEY: op://bic45kuflnwsnxnd67dzcnxjze/5p65mbzr237yyzt2sfnfao3a5a/S3_SECRET_ACCESS_KEY
 
       - name: Extract kubectl version
         id: kubectl-version
@@ -98,23 +100,13 @@ jobs:
 
           dagger call ci "${ARGS[@]}"
 
-      - name: Publish Docs to GHCR
+      - name: Deploy Docs to S3
         if: steps.env.outputs.env == 'prod'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          dagger call publish-docs \
+          dagger call deploy-docs-to-s3 \
             --source=. \
-            --image-name="ghcr.io/shepherdjerred/dpp-docs:latest" \
-            --ghcr-username="${{ github.actor }}" \
-            --ghcr-password=env://GITHUB_TOKEN
-
-          dagger call publish-docs \
-            --source=. \
-            --image-name="ghcr.io/shepherdjerred/dpp-docs:${{ github.sha }}" \
-            --ghcr-username="${{ github.actor }}" \
-            --ghcr-password=env://GITHUB_TOKEN
+            --s3-access-key-id=env:S3_ACCESS_KEY_ID \
+            --s3-secret-access-key=env:S3_SECRET_ACCESS_KEY
 
 permissions:
   contents: read
-  packages: write


### PR DESCRIPTION
## Summary
- Replace GHCR container publishing with S3 (SeaweedFS) deployment for docs
- Remove buildDocsContainer(), publishDocs() functions
- Add deployDocsToS3() using syncToS3() from dagger-utils
- Update workflow to call deploy-docs-to-s3 instead of publish-docs
- Load S3 secrets from 1Password
- Remove packages: write permission

Note: Main app containers remain unchanged, only docs move to S3.

## Test plan
- [ ] CI runs successfully on this branch
- [ ] Merge to main and verify S3 bucket receives updated files
- [ ] Verify docs site is accessible via hostname

🤖 Generated with [Claude Code](https://claude.ai/code)