### PR TITLE
Add Plausible analytics to docs

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,4 +1,10 @@
-{% extends "base.html" %} {% block announce %} Follow <strong>@shepherdjerred</strong> on
+{% extends "base.html" %}
+
+{% block analytics %}
+<script defer data-domain="docs.discord-plays-pokemon.com" src="https://plausible.sjer.red/js/script.js"></script>
+{% endblock %}
+
+{% block announce %} Follow <strong>@shepherdjerred</strong> on
 <a rel="me" href="https://mastodon.social/@shepherdjerred">
   <span class="twemoji mastodon"> {% include ".icons/fontawesome/brands/mastodon.svg" %} </span>
   <strong>Mastodon Social</strong>


### PR DESCRIPTION
## Summary
- Add self-hosted Plausible analytics script to the docs site
- Uses MkDocs Material's `analytics` block for proper integration
- Tracks visits to docs.discord-plays-pokemon.com

## Test plan
- [ ] Verify the Plausible script loads on the docs site
- [ ] Confirm analytics events are being recorded in Plausible dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)